### PR TITLE
Fix device selection

### DIFF
--- a/Audio/Output/OutputCoreAudio.h
+++ b/Audio/Output/OutputCoreAudio.h
@@ -26,7 +26,8 @@
 - (id)initWithController:(OutputNode *)c;
 
 - (BOOL)setup;
-- (BOOL)setOutputDevice:(AudioDeviceID)outputDevice;
+- (OSStatus)setOutputDeviceByID:(AudioDeviceID)deviceID;
+- (BOOL)setOutputDeviceWithDeviceDict:(NSDictionary *)deviceDict;
 - (void)start;
 - (void)pause;
 - (void)resume;

--- a/Cog.xcodeproj/project.pbxproj
+++ b/Cog.xcodeproj/project.pbxproj
@@ -1943,7 +1943,6 @@
 				LastUpgradeCheck = 1100;
 				TargetAttributes = {
 					8D1107260486CEB800E47090 = {
-						DevelopmentTeam = 4S876G9VCD;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/Cog.xcodeproj/project.pbxproj
+++ b/Cog.xcodeproj/project.pbxproj
@@ -329,6 +329,20 @@
 			remoteGlobalIDString = 8D5B49AC048680CD000E48DA;
 			remoteInfo = General;
 		};
+		3D2C77DC23FABECD00B3FAEC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E6B750181612FD00D4576D /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EA4311EA229D651300A5503D;
+			remoteInfo = bsdiff;
+		};
+		3D2C77DE23FABECD00B3FAEC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E6B750181612FD00D4576D /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EA4311A0229D5FBC00A5503D;
+			remoteInfo = ed25519;
+		};
 		566D321A0D538550004466A5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 566D32160D538550004466A5 /* APL.xcodeproj */;
@@ -1758,6 +1772,8 @@
 				8319A68B1F79E99300C168D6 /* generate_appcast */,
 				835C888622CC1853001B4B3F /* generate_keys */,
 				835C888822CC1853001B4B3F /* sign_update */,
+				3D2C77DD23FABECD00B3FAEC /* libbsdiff.a */,
+				3D2C77DF23FABECD00B3FAEC /* libed25519.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2149,6 +2165,20 @@
 			fileType = wrapper.cfbundle;
 			path = General.preferencePane;
 			remoteRef = 17F5622D0C3BD8FB0019975C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3D2C77DD23FABECD00B3FAEC /* libbsdiff.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libbsdiff.a;
+			remoteRef = 3D2C77DC23FABECD00B3FAEC /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3D2C77DF23FABECD00B3FAEC /* libed25519.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libed25519.a;
+			remoteRef = 3D2C77DE23FABECD00B3FAEC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		566D321B0D538550004466A5 /* APL.bundle */ = {

--- a/Preferences/General/OutputsArrayController.m
+++ b/Preferences/General/OutputsArrayController.m
@@ -9,18 +9,21 @@
 	[self setSelectsInsertedObjects:NO];
 	
 	NSDictionary *defaultDevice = [[[NSUserDefaultsController sharedUserDefaultsController] defaults] objectForKey:@"outputDevice"];
-	
+    NSString *defaultDeviceName = defaultDevice[@"name"];
+    NSNumber *defaultDeviceIDNum = defaultDevice[@"deviceID"];
+    AudioDeviceID defaultDeviceID = [defaultDeviceIDNum unsignedIntValue];
+
 	[self enumerateAudioOutputsUsingBlock:
 	 ^(NSString *deviceName, AudioDeviceID deviceID, AudioDeviceID systemDefaultID, BOOL *stop) {
 		NSDictionary *deviceInfo = @{
 			@"name": deviceName,
-			@"deviceID": [NSNumber numberWithUnsignedInt:deviceID],
+			@"deviceID": @(deviceID),
 		};
 		[self addObject:deviceInfo];
         		
 		if (defaultDevice) {
-			if (([[defaultDevice objectForKey:@"deviceID"] isEqualToNumber:[deviceInfo objectForKey:@"deviceID"]]) ||
-				([[defaultDevice objectForKey:@"name"] isEqualToString:[deviceInfo objectForKey:@"name"]])) {
+			if ((deviceID == defaultDeviceID) ||
+				([deviceName isEqualToString:defaultDeviceName])) {
 				[self setSelectedObjects:[NSArray arrayWithObject:deviceInfo]];
 				// Update `outputDevice`, in case the ID has changed.
 				[[NSUserDefaults standardUserDefaults] setObject:deviceInfo forKey:@"outputDevice"];


### PR DESCRIPTION
I have cleaned up the output device code. Everything's seems to be working fine. I could reproduce that an unavailable (in this case USB) audio device will cause no device to be selected in the preferences pane. This seems like reasonable behavior to me. That’s probably what causes the empty selection in your case. We could select the system default in this scenario.