### PR TITLE
Fix apple silicon flac crash

### DIFF
--- a/Audio/CogPluginMulti.m
+++ b/Audio/CogPluginMulti.m
@@ -78,7 +78,10 @@ NSArray * sortClassesByPriority(NSArray * theClasses)
         Class decoder = NSClassFromString(classString);
         theDecoder = [[decoder alloc] init];
         for (NSDictionary *obsItem in cachedObservers) {
-            [theDecoder addObserver:[obsItem objectForKey:@"observer"] forKeyPath:[obsItem objectForKey:@"keyPath"] options:[obsItem objectForKey:@"options"] context:(__bridge void *)([obsItem objectForKey:@"context"])];
+            [theDecoder addObserver:[obsItem objectForKey:@"observer"]
+                         forKeyPath:[obsItem objectForKey:@"keyPath"]
+                            options:[[obsItem objectForKey:@"options"] unsignedIntegerValue]
+                            context:(__bridge void *)([obsItem objectForKey:@"context"])];
         }
         if ([theDecoder open:source])
             return YES;
@@ -118,7 +121,11 @@ NSArray * sortClassesByPriority(NSArray * theClasses)
 /* By the current design, the core adds its observers to decoders before they are opened */
 - (void)addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options context:(void *)context
 {
-    [cachedObservers addObject:[NSDictionary dictionaryWithObjectsAndKeys:observer, @"observer", keyPath, @"keyPath", options, @"options", context, @"context", nil]];
+    if(context != nil) {
+        [cachedObservers addObject:[NSDictionary dictionaryWithObjectsAndKeys:observer, @"observer", keyPath, @"keyPath", @(options), @"options", context, @"context", nil]];
+    } else {
+        [cachedObservers addObject:[NSDictionary dictionaryWithObjectsAndKeys:observer, @"observer", keyPath, @"keyPath", @(options), @"options", nil]];
+    }
 }
 
 /* And this is currently called after the decoder is closed */

--- a/Cog.xcodeproj/project.pbxproj
+++ b/Cog.xcodeproj/project.pbxproj
@@ -925,7 +925,7 @@
 		83859520234FEB35004E9946 /* Cog.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Cog.entitlements; sourceTree = "<group>"; };
 		838F84FF25687C5C00C3E614 /* Cog-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Cog-Bridging-Header.h"; sourceTree = "<group>"; };
 		838F850025687C5C00C3E614 /* PlaybackStatusToHiddenTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlaybackStatusToHiddenTransformer.swift; path = Transformers/PlaybackStatusToHiddenTransformer.swift; sourceTree = "<group>"; };
-		838F851B256B4AC400C3E614 /* icon_blank.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = icon_blank.icns; path = ../../../../Desktop/icon_blank.icns; sourceTree = "<group>"; };
+		838F851B256B4AC400C3E614 /* icon_blank.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = icon_blank.icns; sourceTree = "<group>"; };
 		838F851D256B4E5E00C3E614 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = ThirdParty/Frameworks/Sparkle.framework; sourceTree = "<group>"; };
 		8399D4E01805A55000B503B1 /* XmlContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XmlContainer.m; sourceTree = "<group>"; };
 		8399D4E11805A55000B503B1 /* XmlContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XmlContainer.h; sourceTree = "<group>"; };

--- a/Plugins/Flac/FlacDecoder.m
+++ b/Plugins/Flac/FlacDecoder.m
@@ -323,26 +323,12 @@ void ErrorCallback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorS
 
 + (NSArray *)fileTypes
 {
-    if (@available(macOS 10.13, *))
-    {
-        return [NSArray array];
-    }
-    else
-    {
-        return [NSArray arrayWithObjects:@"flac", nil];
-    }
+	return [NSArray arrayWithObjects:@"flac", nil];
 }
 
 + (NSArray *)mimeTypes
 {
-    if (@available(macOS 10.13, *))
-    {
-        return [NSArray array];
-    }
-    else
-    {
-        return [NSArray arrayWithObjects:@"audio/x-flac", nil];
-    }
+	return [NSArray arrayWithObjects:@"audio/x-flac", nil];
 }
 
 + (float)priority


### PR DESCRIPTION
Fixes FLAC playback crash on Apple Silicon

- Avoid creating an NSDictionary with NULL context object (https://github.com/kode54/Cog/blob/master/Audio/Chain/InputNode.m#L81 passes NULL as context, so this must be handled in NSDictionary creation
- When calling `addObserver`, downgrade `options` from `NSNumber *` to `NSKeyValueObservingOptions` (aka `NSUInteger`)

Not sure why this would be specific to Apple Silicon, but it did fix FLAC playback on my DTK. Doesn't seem related to libFLAC on ARM.

This reverts last night's changes to `FlacDecoder.m`. Even if you continue using Core Audio for FLAC Decoding, this change should help with formats that use `CogPluginMulti.m` ¯\\_(ツ)_/¯.