### PR TITLE
Updated Ogg and Vorbis targets Base SDK.

### DIFF
--- a/Frameworks/Ogg/macosx/Ogg.xcodeproj/project.pbxproj
+++ b/Frameworks/Ogg/macosx/Ogg.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = ogg;
+				SDKROOT = macosx;
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -414,6 +415,7 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = ogg;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;

--- a/Frameworks/Vorbis/macosx/Vorbis.xcodeproj/project.pbxproj
+++ b/Frameworks/Vorbis/macosx/Vorbis.xcodeproj/project.pbxproj
@@ -920,6 +920,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbis;
+				SDKROOT = macosx;
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -936,6 +937,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbis;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -955,6 +957,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbisenc;
+				SDKROOT = macosx;
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -972,6 +975,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbisenc;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -990,6 +994,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbisfile;
+				SDKROOT = macosx;
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -1006,6 +1011,7 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				PRODUCT_NAME = vorbisfile;
+				SDKROOT = macosx;
 				ZERO_LINK = NO;
 			};
 			name = Release;


### PR DESCRIPTION
Targets:
- libogg (static)
- libvorbis (static)
- libvorbisenc (static)
- libvorbisfile (static)